### PR TITLE
Allow DND.

### DIFF
--- a/org.gnome.gitlab.YaLTeR.VideoTrimmer.json
+++ b/org.gnome.gitlab.YaLTeR.VideoTrimmer.json
@@ -22,7 +22,8 @@
         "--socket=fallback-x11",
         "--socket=wayland",
         "--socket=pulseaudio",
-        "--device=dri"
+        "--device=dri",
+        "--filesystem=xdg-videos"
     ],
     "cleanup" : [
         "/bin/blueprint-compiler",


### PR DESCRIPTION
This fixes the error with drag and drop. maybe consider saying in the error that you don't have permission to view the file, if the video is not in the Videos folder.