### PR TITLE
Update VideoTrimmer runtime to 46

### DIFF
--- a/org.gnome.gitlab.YaLTeR.VideoTrimmer.json
+++ b/org.gnome.gitlab.YaLTeR.VideoTrimmer.json
@@ -1,7 +1,7 @@
 {
     "app-id" : "org.gnome.gitlab.YaLTeR.VideoTrimmer",
     "runtime" : "org.gnome.Platform",
-    "runtime-version" : "45",
+    "runtime-version" : "46",
     "sdk" : "org.gnome.Sdk",
     "sdk-extensions" : [
         "org.freedesktop.Sdk.Extension.rust-stable"


### PR DESCRIPTION
Update VideoTrimmer runtime to 46 because runtime 45 will be EOL on 2024-09-14.