### PR TITLE
Update runtime to 50

### DIFF
--- a/org.gnome.gitlab.YaLTeR.VideoTrimmer.yml
+++ b/org.gnome.gitlab.YaLTeR.VideoTrimmer.yml
@@ -1,16 +1,9 @@
 app-id: org.gnome.gitlab.YaLTeR.VideoTrimmer
 runtime: org.gnome.Platform
-runtime-version: '48'
+runtime-version: '50'
 sdk: org.gnome.Sdk
 sdk-extensions:
   - org.freedesktop.Sdk.Extension.rust-stable
-add-extensions:
-  org.freedesktop.Platform.ffmpeg-full:
-    directory: lib/ffmpeg
-    version: '24.08'
-    add-ld-path: .
-cleanup-commands:
-  - mkdir -p ${FLATPAK_DEST}/lib/ffmpeg
 command: video-trimmer
 finish-args:
   - --share=ipc
@@ -18,22 +11,11 @@ finish-args:
   - --socket=wayland
   - --socket=pulseaudio
   - --device=dri
-cleanup:
-  - /bin/blueprint-compiler
-  - /lib/pkgconfig
 build-options:
   append-path: /usr/lib/sdk/rust-stable/bin
   env:
     RUSTFLAGS: -C force-frame-pointers=yes
 modules:
-  - name: blueprint
-    buildsystem: meson
-    cleanup:
-      - '*'
-    sources:
-      - type: git
-        url: https://gitlab.gnome.org/jwestman/blueprint-compiler.git
-        commit: 04ef0944db56ab01307a29aaa7303df6067cb3c0
   - name: video-trimmer
     buildsystem: meson
     sources:


### PR DESCRIPTION
- Update runtime to 50
- Drop the ffmpeg extension, which is already provided by the runtime
- Drop the blueprint compiler, which is already provided by the runtime
- Drop ineffective cleanup commands

---

PS:

> Yea, I was gonna do the necessary UI widget updates at the same time. I won't let it EOL dw

See: https://github.com/flathub/org.gnome.gitlab.YaLTeR.VideoTrimmer/pull/14#issuecomment-3765350727
